### PR TITLE
fix:incorrect value assignment for message types in motor drivers

### DIFF
--- a/include/gn10_can/core/can_id.hpp
+++ b/include/gn10_can/core/can_id.hpp
@@ -51,9 +51,9 @@ enum class MsgTypeEmergencyStop : uint8_t {
 enum class MsgTypeMotorDriver : uint8_t {
     Init           = 0,
     Target         = 1,
-    Gain           = 3,
-    Feedback       = 4,
-    HardwareStatus = 5,
+    Gain           = 2,
+    Feedback       = 3,
+    HardwareStatus = 4,
 };
 
 /**


### PR DESCRIPTION
もともと、0,1,3,4,5のように値が割り振られており、2が飛ばされていた。
```c++
enum class MsgTypeMotorDriver : uint8_t {
    Init           = 0,
    Target         = 1,
    Gain           = 3,
    Feedback       = 4,
    HardwareStatus = 5,
};
```
単純な割当ミスなので、修正した。
ただし、変更箇所はプロトコルに影響するのでこのライブラリを使用する対象すべてを更新せねばならない。