### PR TITLE
add:overloads for pack and unpack to make them symmetrical

### DIFF
--- a/include/gn10_can/utils/can_converter.hpp
+++ b/include/gn10_can/utils/can_converter.hpp
@@ -79,5 +79,21 @@ bool pack(std::array<uint8_t, N>& buffer, uint8_t start_byte, T value) {
     return pack(buffer.data(), N, start_byte, value);
 }
 
+/**
+ * @brief std::arrayバッファからPOD型データを取り出す関数
+ *
+ * @tparam T 取り出すPOD型データの型
+ * @tparam N バッファのサイズ
+ * @param buffer データを取り出すバッファ
+ * @param start_byte 開始バイト位置
+ * @param out_value 取り出したPOD型データの格納先
+ * @return true 成功
+ * @return false 失敗（バッファオーバーフローなど）
+ */
+template <typename T, size_t N>
+bool unpack(const std::array<uint8_t, N>& buffer, uint8_t start_byte, T& out_value) {
+    return unpack(buffer.data(), N, start_byte, out_value);
+}
+
 }  // namespace converter
 }  // namespace gn10_can


### PR DESCRIPTION
unpackとpackの対称性を持たせるため、unpack側にオーバーライド関数（array）を追加