### PR TITLE
chore: clang-formatのAlignConsecutiveMacros の v15+ 限定構文を v14 互換の Conse…

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -30,8 +30,7 @@ BinPackParameters:     false
 BinPackArguments:      false
 
 # マクロはSTM32向けに縦を揃える
-AlignConsecutiveMacros:
-    Enabled: true
+AlignConsecutiveMacros: Consecutive
 # ビットフィールドは縦のつながりがあるので揃える
 AlignConsecutiveBitFields: Consecutive
 # 設定値やパラメータの代入は、視認性向上のため縦に揃える


### PR DESCRIPTION
…cutive に修正