### PR TITLE
Feat/fdcan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 set(SOURCES
     src/core/can_bus.cpp
+    src/core/fdcan_bus.cpp
     src/devices/motor_driver_types.cpp
     src/devices/motor_driver_client.cpp
     src/devices/motor_driver_server.cpp

--- a/include/gn10_can/core/can_frame.hpp
+++ b/include/gn10_can/core/can_frame.hpp
@@ -23,19 +23,16 @@ namespace gn10_can {
  * @brief CANフレーム構造体
  *
  */
-struct CANFrame {
-    static constexpr std::size_t MAX_DLC = 8;
+template <std::size_t MaxDLC>
+struct BasicCANFrame {
+    static constexpr std::size_t MAX_DLC = MaxDLC;
 
-    uint32_t id = 0;                      // CAN ID
-    std::array<uint8_t, MAX_DLC> data{};  // Data payload
-    uint8_t dlc = 0;                      // Data length code (DLC)
-
-    // additional attribute
+    uint32_t id = 0;                     // CAN ID
+    std::array<uint8_t, MaxDLC> data{};  // データ配列
+    uint8_t dlc      = 0;                // データ長 (DLC)
     bool is_extended = false;
-    bool is_rtr      = false;
-    bool is_error    = false;
 
-    CANFrame() = default;
+    BasicCANFrame() = default;
 
     /**
      * @brief CANフレーム作成ヘルパー関数
@@ -46,10 +43,10 @@ struct CANFrame {
      * @param cmd コマンド
      * @param payload 送信データ
      * @param length 送信データの長さ
-     * @return CANFrame 生成したCANフレーム
+     * @return BasicCANFrame 生成したCANフレーム
      */
     template <typename CmdEnum>
-    static CANFrame make(
+    static BasicCANFrame make(
         id::DeviceType type,
         uint8_t dev_id,
         CmdEnum cmd,
@@ -57,7 +54,7 @@ struct CANFrame {
         std::size_t length     = 0
     )
     {
-        CANFrame frame;
+        BasicCANFrame frame;
         frame.id = id::pack(type, dev_id, cmd);
         frame.set_data(payload, length);
         return frame;
@@ -71,10 +68,10 @@ struct CANFrame {
      * @param dev_id デバイスのID
      * @param cmd コマンド
      * @param payload 送信データ（{データ配列}の様に関数呼び出し時に作成可能）
-     * @return CANFrame 生成したCANフレーム
+     * @return BasicCANFrame 生成したCANフレーム
      */
     template <typename CmdEnum>
-    static CANFrame make(
+    static BasicCANFrame make(
         id::DeviceType type, uint8_t dev_id, CmdEnum cmd, std::initializer_list<uint8_t> payload
     )
     {
@@ -129,10 +126,9 @@ struct CANFrame {
      * @return true 等しい
      * @return false 等しくない
      */
-    bool operator==(const CANFrame& other) const noexcept
+    bool operator==(const BasicCANFrame& other) const noexcept
     {
-        if (id != other.id || dlc != other.dlc || is_extended != other.is_extended ||
-            is_rtr != other.is_rtr || is_error != other.is_error) {
+        if (id != other.id || dlc != other.dlc || is_extended != other.is_extended) {
             return false;
         }
 
@@ -149,10 +145,13 @@ struct CANFrame {
      * @return true 等しくない
      * @return false 等しい
      */
-    bool operator!=(const CANFrame& other) const noexcept
+    bool operator!=(const BasicCANFrame& other) const noexcept
     {
         return !(*this == other);
     }
 };
+
+using CANFrame   = BasicCANFrame<8>;
+using FDCANFrame = BasicCANFrame<64>;
 
 }  // namespace gn10_can

--- a/include/gn10_can/core/can_frame.hpp
+++ b/include/gn10_can/core/can_frame.hpp
@@ -19,12 +19,14 @@
 
 namespace gn10_can {
 
+namespace detail {
+
 /**
  * @brief CANフレーム構造体
  *
  */
 template <std::size_t MaxDLC>
-struct BasicCANFrame {
+struct CANFrame {
     static constexpr std::size_t MAX_DLC = MaxDLC;
 
     uint32_t id = 0;                     // CAN ID
@@ -32,7 +34,7 @@ struct BasicCANFrame {
     uint8_t dlc      = 0;                // データ長 (DLC)
     bool is_extended = false;
 
-    BasicCANFrame() = default;
+    CANFrame() = default;
 
     /**
      * @brief CANフレーム作成ヘルパー関数
@@ -43,10 +45,10 @@ struct BasicCANFrame {
      * @param cmd コマンド
      * @param payload 送信データ
      * @param length 送信データの長さ
-     * @return BasicCANFrame 生成したCANフレーム
+     * @return CANFrame 生成したCANフレーム
      */
     template <typename CmdEnum>
-    static BasicCANFrame make(
+    static CANFrame make(
         id::DeviceType type,
         uint8_t dev_id,
         CmdEnum cmd,
@@ -54,7 +56,7 @@ struct BasicCANFrame {
         std::size_t length     = 0
     )
     {
-        BasicCANFrame frame;
+        CANFrame frame;
         frame.id = id::pack(type, dev_id, cmd);
         frame.set_data(payload, length);
         return frame;
@@ -68,10 +70,10 @@ struct BasicCANFrame {
      * @param dev_id デバイスのID
      * @param cmd コマンド
      * @param payload 送信データ（{データ配列}の様に関数呼び出し時に作成可能）
-     * @return BasicCANFrame 生成したCANフレーム
+     * @return CANFrame 生成したCANフレーム
      */
     template <typename CmdEnum>
-    static BasicCANFrame make(
+    static CANFrame make(
         id::DeviceType type, uint8_t dev_id, CmdEnum cmd, std::initializer_list<uint8_t> payload
     )
     {
@@ -126,7 +128,7 @@ struct BasicCANFrame {
      * @return true 等しい
      * @return false 等しくない
      */
-    bool operator==(const BasicCANFrame& other) const noexcept
+    bool operator==(const CANFrame& other) const noexcept
     {
         if (id != other.id || dlc != other.dlc || is_extended != other.is_extended) {
             return false;
@@ -145,13 +147,14 @@ struct BasicCANFrame {
      * @return true 等しくない
      * @return false 等しい
      */
-    bool operator!=(const BasicCANFrame& other) const noexcept
+    bool operator!=(const CANFrame& other) const noexcept
     {
         return !(*this == other);
     }
 };
+}  // namespace detail
 
-using CANFrame   = BasicCANFrame<8>;
-using FDCANFrame = BasicCANFrame<64>;
+using FDCANFrame = detail::CANFrame<64>;
+using CANFrame   = detail::CANFrame<8>;
 
 }  // namespace gn10_can

--- a/include/gn10_can/core/can_frame.hpp
+++ b/include/gn10_can/core/can_frame.hpp
@@ -154,7 +154,6 @@ struct CANFrame {
 };
 }  // namespace detail
 
-using FDCANFrame = detail::CANFrame<64>;
-using CANFrame   = detail::CANFrame<8>;
+using CANFrame = detail::CANFrame<8>;
 
 }  // namespace gn10_can

--- a/include/gn10_can/core/fdcan_bus.hpp
+++ b/include/gn10_can/core/fdcan_bus.hpp
@@ -1,0 +1,90 @@
+/**
+ * @file can_bus.hpp
+ * @author Gento Aiba (aiba-gento)
+ * @brief
+ * 物理的なCANバスをソフトウェア上で表現したクラス。デバイスの接続(Attach)と、メッセージのルーティング(Dispatch)を担当します。
+ * @version 0.1.0
+ * @date 2026-01-28
+ *
+ * @copyright Copyright (c) 2026 Gento Aiba
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "gn10_can/drivers/driver_interface.hpp"
+
+namespace gn10_can {
+
+class FDCANDevice;
+
+/**
+ * @brief
+ * 物理的なCANバスをソフトウェア上で表現したクラス。デバイスの接続(Attach)と、メッセージのルーティング(Dispatch)を担当します。
+ *
+ */
+class FDCANBus
+{
+public:
+    static constexpr std::size_t MAX_DEVICES = 16;  // 最大登録デバイス数
+
+    /**
+     * @brief FDCANBusクラスのコンストラクタ
+     *
+     * @param driver CANドライバーインターフェースの参照
+     */
+    explicit FDCANBus(drivers::ICanDriver& driver);
+
+    /**
+     * @brief CANパケットの受信とデバイスへのルーティング処理
+     *
+     * 受信データを読み込み、適切なデバイスに渡します。
+     */
+    void update();
+
+    /**
+     * @brief CANフレーム送信関数
+     *
+     * @param frame 送信するCANフレーム
+     * @return true 送信成功
+     * @return false 送信失敗
+     */
+    bool send_frame(const CANFrame& frame);
+
+private:
+    friend class FDCANDevice;
+
+    /**
+     * @brief デバイスをバスに接続する (RAII内部利用)
+     *
+     * FDCANDeviceのコンストラクタから自動的に呼び出されます。
+     *
+     * @param device 登録するデバイスへのポインタ
+     * @return true 登録成功
+     * @return false 登録失敗（デバイス数上限）
+     */
+    bool attach(FDCANDevice* device);
+
+    /**
+     * @brief デバイスをバスから切断する (RAII内部利用)
+     *
+     * FDCANDeviceのデストラクタから自動的に呼び出されます。
+     *
+     * @param device 登録解除するデバイスへのポインタ
+     */
+    void detach(FDCANDevice* device);
+
+    /**
+     * @brief 受信したフレームを適切なデバイスに配送する
+     *
+     * @param frame 受信フレーム
+     */
+    void dispatch(const CANFrame& frame);
+
+    drivers::ICanDriver& driver_;                      // CANドライバーインターフェースの参照を保持
+    std::array<FDCANDevice*, MAX_DEVICES> devices_{};  // 登録されているデバイスの配列
+    std::size_t device_count_ = 0;                     // 登録されているデバイス数
+};
+}  // namespace gn10_can

--- a/include/gn10_can/core/fdcan_bus.hpp
+++ b/include/gn10_can/core/fdcan_bus.hpp
@@ -14,8 +14,7 @@
 #include <array>
 #include <cstddef>
 
-#include "gn10_can/core/fdcan_frame.hpp"
-#include "gn10_can/drivers/driver_interface.hpp"
+#include "gn10_can/drivers/fdcan_driver_interface.hpp"
 
 namespace gn10_can {
 
@@ -36,7 +35,7 @@ public:
      *
      * @param driver FDCANドライバーインターフェースの参照
      */
-    explicit FDCANBus(drivers::ICanDriver& driver);
+    explicit FDCANBus(drivers::IFDCANDriver& driver);
 
     /**
      * @brief FDCANパケットの受信とデバイスへのルーティング処理
@@ -84,7 +83,7 @@ private:
      */
     void dispatch(const FDCANFrame& frame);
 
-    drivers::ICanDriver& driver_;                      // CANドライバーインターフェースの参照を保持
+    drivers::IFDCANDriver& driver_;                    // CANドライバーインターフェースの参照を保持
     std::array<FDCANDevice*, MAX_DEVICES> devices_{};  // 登録されているデバイスの配列
     std::size_t device_count_ = 0;                     // 登録されているデバイス数
 };

--- a/include/gn10_can/core/fdcan_bus.hpp
+++ b/include/gn10_can/core/fdcan_bus.hpp
@@ -2,9 +2,9 @@
  * @file can_bus.hpp
  * @author Gento Aiba (aiba-gento)
  * @brief
- * 物理的なCANバスをソフトウェア上で表現したクラス。デバイスの接続(Attach)と、メッセージのルーティング(Dispatch)を担当します。
+ * 物理的なFDCANバスをソフトウェア上で表現したクラス。デバイスの接続(Attach)と、メッセージのルーティング(Dispatch)を担当します。
  * @version 0.1.0
- * @date 2026-01-28
+ * @date 2026-04-01
  *
  * @copyright Copyright (c) 2026 Gento Aiba
  * SPDX-License-Identifier: Apache-2.0
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstddef>
 
+#include "gn10_can/core/fdcan_frame.hpp"
 #include "gn10_can/drivers/driver_interface.hpp"
 
 namespace gn10_can {
@@ -22,7 +23,7 @@ class FDCANDevice;
 
 /**
  * @brief
- * 物理的なCANバスをソフトウェア上で表現したクラス。デバイスの接続(Attach)と、メッセージのルーティング(Dispatch)を担当します。
+ * 物理的なFDCANバスをソフトウェア上で表現したクラス。デバイスの接続(Attach)と、メッセージのルーティング(Dispatch)を担当します。
  *
  */
 class FDCANBus
@@ -33,25 +34,25 @@ public:
     /**
      * @brief FDCANBusクラスのコンストラクタ
      *
-     * @param driver CANドライバーインターフェースの参照
+     * @param driver FDCANドライバーインターフェースの参照
      */
     explicit FDCANBus(drivers::ICanDriver& driver);
 
     /**
-     * @brief CANパケットの受信とデバイスへのルーティング処理
+     * @brief FDCANパケットの受信とデバイスへのルーティング処理
      *
      * 受信データを読み込み、適切なデバイスに渡します。
      */
     void update();
 
     /**
-     * @brief CANフレーム送信関数
+     * @brief FDCANフレーム送信関数
      *
      * @param frame 送信するCANフレーム
      * @return true 送信成功
      * @return false 送信失敗
      */
-    bool send_frame(const CANFrame& frame);
+    bool send_frame(const FDCANFrame& frame);
 
 private:
     friend class FDCANDevice;
@@ -81,7 +82,7 @@ private:
      *
      * @param frame 受信フレーム
      */
-    void dispatch(const CANFrame& frame);
+    void dispatch(const FDCANFrame& frame);
 
     drivers::ICanDriver& driver_;                      // CANドライバーインターフェースの参照を保持
     std::array<FDCANDevice*, MAX_DEVICES> devices_{};  // 登録されているデバイスの配列

--- a/include/gn10_can/core/fdcan_device.hpp
+++ b/include/gn10_can/core/fdcan_device.hpp
@@ -1,0 +1,117 @@
+/**
+ * @file fdcan_device.hpp
+ * @author Gento Aiba (aiba-gento)
+ * @brief FDCAN対応デバイスの抽象化クラスのヘッダーファイル
+ * @version 0.1.0
+ * @date 2026-01-10
+ *
+ * @copyright Copyright (c) 2026 Gento Aiba
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "gn10_can/core/can_id.hpp"
+#include "gn10_can/core/fdcan_bus.hpp"
+#include "gn10_can/core/fdcan_frame.hpp"
+
+namespace gn10_can {
+
+/**
+ * @brief FDCAN対応デバイスの抽象化クラス
+ * @note 各デバイス毎に具体化クラスを継承して定義してください。
+ *
+ */
+class FDCANDevice
+{
+public:
+    /**
+     * @brief デバイス抽象化クラスのコンストラクタ
+     *
+     * @param bus
+     * CANパケットを送信する為にFDCANBusクラスのインスタンスポインタを渡す
+     * @param device_type デバイスの種類
+     * @param device_id
+     * デバイスのID（同じデバイスの種類のデバイスが複数あることを配慮して、0,1,2,..）
+     */
+    FDCANDevice(FDCANBus& bus, id::DeviceType device_type, uint8_t device_id)
+        : bus_(bus), device_type_(device_type), device_id_(device_id)
+    {
+        bus_.attach(this);
+    }
+
+    virtual ~FDCANDevice()
+    {
+        bus_.detach(this);
+    }
+
+    // コピーとムーブを禁止 (RAIIによるデバイス登録の一意性を保つため)
+    FDCANDevice(const FDCANDevice&)            = delete;
+    FDCANDevice& operator=(const FDCANDevice&) = delete;
+    FDCANDevice(FDCANDevice&&)                 = delete;
+    FDCANDevice& operator=(FDCANDevice&&)      = delete;
+
+    /**
+     * @brief CANパケット受信時の呼び出し関数
+     *
+     * @param frame 受信したCANパケット
+     */
+    virtual void on_receive(const CANFrame& frame) = 0;
+
+    /**
+     * @brief ルーティングIDを取得
+     *
+     * コマンド部を除いた、デバイス特定用の上位ビット列を返します。
+     *
+     * @return uint32_t Routing ID (Type + DeviceID)
+     */
+    uint32_t get_routing_id() const
+    {
+        // CANFrame::get_routing_id() と同じ形式 (Type << BIT_WIDTH_DEV_ID) | DeviceID を返す
+        return (static_cast<uint32_t>(device_type_) << id::BIT_WIDTH_DEV_ID) |
+               static_cast<uint32_t>(device_id_);
+    }
+
+protected:
+    /**
+     * @brief コマンド・データ・データ長からCANフレームを作成しCANManagerを使用して送信
+     *
+     * @tparam CmdEnum コマンドのEnum Class
+     * @param command
+     * コマンド（データの種類を示す、CAN通信時のデータは指令として見れるためコマンドとして見なす）
+     * @param data 送信データ
+     * @param len 送信データ長（MAX:8）
+     * @return true 送信成功（CANDriverの継承後クラスによって定義）
+     * @return false 送信失敗（CANDriverの継承後クラスによって定義）
+     */
+    template <typename CmdEnum>
+    bool send(CmdEnum command, const uint8_t* data = nullptr, std::size_t len = 0)
+    {
+        auto frame = CANFrame::make(device_type_, device_id_, command, data, len);
+        return bus_.send_frame(frame);
+    }
+
+    /**
+     * @brief コマンド・データ(array)からCANフレームを作成しCANManagerを使用して送信
+     *
+     * @tparam CmdEnum コマンドのEnum Class
+     * @tparam N 送信データ長：1~8
+     * @param command
+     * コマンド（データの種類を示す、CAN通信時のデータは指令として見れるためコマンドとして見なす）
+     * @param data 送信データ（要素数1~8のarray配列）
+     * @return true 送信成功（CANDriverの継承後クラスによって定義）
+     * @return false 送信失敗（CANDriverの継承後クラスによって定義）
+     */
+    template <typename CmdEnum, std::size_t N>
+    bool send(CmdEnum command, const std::array<uint8_t, N>& data)
+    {
+        return send(command, data.data(), static_cast<uint8_t>(data.size()));
+    }
+
+    FDCANBus& bus_;               // CAN通信を統括するクラスの参照
+    id::DeviceType device_type_;  // デバイスの種類
+    uint8_t device_id_;           // デバイスID
+};
+}  // namespace gn10_can

--- a/include/gn10_can/core/fdcan_device.hpp
+++ b/include/gn10_can/core/fdcan_device.hpp
@@ -58,7 +58,7 @@ public:
      *
      * @param frame 受信したCANパケット
      */
-    virtual void on_receive(const CANFrame& frame) = 0;
+    virtual void on_receive(const FDCANFrame& frame) = 0;
 
     /**
      * @brief ルーティングIDを取得
@@ -69,7 +69,7 @@ public:
      */
     uint32_t get_routing_id() const
     {
-        // CANFrame::get_routing_id() と同じ形式 (Type << BIT_WIDTH_DEV_ID) | DeviceID を返す
+        // FDCANFrame::get_routing_id() と同じ形式 (Type << BIT_WIDTH_DEV_ID) | DeviceID を返す
         return (static_cast<uint32_t>(device_type_) << id::BIT_WIDTH_DEV_ID) |
                static_cast<uint32_t>(device_id_);
     }
@@ -89,7 +89,7 @@ protected:
     template <typename CmdEnum>
     bool send(CmdEnum command, const uint8_t* data = nullptr, std::size_t len = 0)
     {
-        auto frame = CANFrame::make(device_type_, device_id_, command, data, len);
+        auto frame = FDCANFrame::make(device_type_, device_id_, command, data, len);
         return bus_.send_frame(frame);
     }
 

--- a/include/gn10_can/core/fdcan_device.hpp
+++ b/include/gn10_can/core/fdcan_device.hpp
@@ -3,7 +3,7 @@
  * @author Gento Aiba (aiba-gento)
  * @brief FDCAN対応デバイスの抽象化クラスのヘッダーファイル
  * @version 0.1.0
- * @date 2026-01-10
+ * @date 2026-04-01
  *
  * @copyright Copyright (c) 2026 Gento Aiba
  * SPDX-License-Identifier: Apache-2.0
@@ -82,7 +82,7 @@ protected:
      * @param command
      * コマンド（データの種類を示す、CAN通信時のデータは指令として見れるためコマンドとして見なす）
      * @param data 送信データ
-     * @param len 送信データ長（MAX:8）
+     * @param len 送信データ長（MAX:64）
      * @return true 送信成功（CANDriverの継承後クラスによって定義）
      * @return false 送信失敗（CANDriverの継承後クラスによって定義）
      */
@@ -97,10 +97,10 @@ protected:
      * @brief コマンド・データ(array)からCANフレームを作成しCANManagerを使用して送信
      *
      * @tparam CmdEnum コマンドのEnum Class
-     * @tparam N 送信データ長：1~8
+     * @tparam N 送信データ長：1~64
      * @param command
      * コマンド（データの種類を示す、CAN通信時のデータは指令として見れるためコマンドとして見なす）
-     * @param data 送信データ（要素数1~8のarray配列）
+     * @param data 送信データ（要素数1~64のarray配列）
      * @return true 送信成功（CANDriverの継承後クラスによって定義）
      * @return false 送信失敗（CANDriverの継承後クラスによって定義）
      */

--- a/include/gn10_can/core/fdcan_frame.hpp
+++ b/include/gn10_can/core/fdcan_frame.hpp
@@ -1,0 +1,18 @@
+/**
+ * @file fdcan_frame.hpp
+ * @author Gento Aiba (aiba-gento)
+ * @brief FDCANフレーム構造体のヘッダーファイル
+ * @version 0.1.0
+ * @date 2026-04-01
+ *
+ * @copyright Copyright (c) 2026
+ *
+ */
+#pragma once
+#include "gn10_can/core/can_frame.hpp"
+
+namespace gn10_can {
+
+using FDCANFrame = detail::CANFrame<64>;
+
+}  // namespace gn10_can

--- a/include/gn10_can/drivers/fdcan_driver_interface.hpp
+++ b/include/gn10_can/drivers/fdcan_driver_interface.hpp
@@ -1,0 +1,46 @@
+/**
+ * @file driver_interface.hpp
+ * @author Gento Aiba (aiba-gento)
+ * @brief CAN通信ハードウェアインターフェースの抽象化クラスのヘッダーファイル
+ * @version 0.1.0
+ * @date 2026-01-10
+ *
+ * @copyright Copyright (c) 2026 Gento Aiba
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include "gn10_can/core/fdcan_frame.hpp"
+
+namespace gn10_can {
+namespace drivers {
+
+/**
+ * @brief CAN通信ハードウェアインターフェースの抽象化クラス
+ *
+ */
+class IFDCANDriver
+{
+public:
+    virtual ~IFDCANDriver() = default;
+
+    /**
+     * @brief CANフレーム送信関数
+     *
+     * @param frame 送信するCANフレーム
+     * @return true 送信成功
+     * @return false 送信失敗
+     */
+    virtual bool send(const FDCANFrame& frame) = 0;
+
+    /**
+     * @brief CANフレーム受信関数
+     *
+     * @param out_frame 受信したCANフレームの格納先
+     * @return true 受信成功
+     * @return false 受信失敗（受信データなしなど）
+     */
+    virtual bool receive(FDCANFrame& out_frame) = 0;
+};
+}  // namespace drivers
+}  // namespace gn10_can

--- a/src/core/fdcan_bus.cpp
+++ b/src/core/fdcan_bus.cpp
@@ -7,7 +7,7 @@
 
 namespace gn10_can {
 
-FDCANBus::FDCANBus(drivers::ICanDriver& driver) : driver_(driver), devices_{}, device_count_(0) {}
+FDCANBus::FDCANBus(drivers::IFDCANDriver& driver) : driver_(driver), devices_{}, device_count_(0) {}
 
 void FDCANBus::update()
 {

--- a/src/core/fdcan_bus.cpp
+++ b/src/core/fdcan_bus.cpp
@@ -1,0 +1,63 @@
+#include "gn10_can/core/fdcan_bus.hpp"
+
+#include <cstddef>
+
+#include "gn10_can/core/can_id.hpp"
+#include "gn10_can/core/fdcan_device.hpp"
+
+namespace gn10_can {
+
+FDCANBus::FDCANBus(drivers::ICanDriver& driver) : driver_(driver), devices_{}, device_count_(0) {}
+
+void FDCANBus::update()
+{
+    FDCANFrame frame;
+    while (driver_.receive(frame)) {
+        dispatch(frame);
+    }
+}
+
+void FDCANBus::dispatch(const FDCANFrame& frame)
+{
+    uint32_t routing_id = frame.get_routing_id();
+
+    for (std::size_t i = 0; i < device_count_; i++) {
+        FDCANDevice* device = devices_[i];
+        if (!device) {
+            continue;
+        }
+
+        if (routing_id == device->get_routing_id()) {
+            device->on_receive(frame);
+        }
+    }
+}
+
+bool FDCANBus::send_frame(const FDCANFrame& frame)
+{
+    return driver_.send(frame);
+}
+
+bool FDCANBus::attach(FDCANDevice* device)
+{
+    if (device_count_ < MAX_DEVICES && device != nullptr) {
+        devices_[device_count_++] = device;
+        return true;
+    }
+    return false;
+}
+
+void FDCANBus::detach(FDCANDevice* device)
+{
+    for (std::size_t i = 0; i < device_count_; i++) {
+        if (devices_[i] == device) {
+            // 見つかった場所を削除し、最後の要素を持ってきて穴埋めする（Orderは変わるが効率的）
+            // ポインタを移動
+            devices_[i]             = devices_[--device_count_];
+            devices_[device_count_] = nullptr;  // Clear logic
+            return;
+        }
+    }
+}
+
+}  // namespace gn10_can

--- a/tests/test_can_frame.cpp
+++ b/tests/test_can_frame.cpp
@@ -11,8 +11,6 @@ TEST(CANFrameTest, DefaultConstructor)
     EXPECT_EQ(frame.id, 0);
     EXPECT_EQ(frame.dlc, 0);
     EXPECT_FALSE(frame.is_extended);
-    EXPECT_FALSE(frame.is_rtr);
-    EXPECT_FALSE(frame.is_error);
 }
 
 TEST(CANFrameTest, MakeWithPointer)


### PR DESCRIPTION
## 関連Issue
closes #49 

## 変更内容
FDCANに対応しました。
まだデバイス追加していませんが、データサイズが64byteまで対応できたはずです。
Classic / FDCAN を完全に別スタックとして定義しました。
理由は既存のコードを破壊しないようにするためです。

## 動作確認
- ビルド通過済み
- テストは済んでいない！！

## レビュー観点
FDCANに変更漏れがないかどうか？