### PR TITLE
Feat/robot control hub

### DIFF
--- a/include/gn10_can/core/can_id.hpp
+++ b/include/gn10_can/core/can_id.hpp
@@ -32,7 +32,8 @@ enum class DeviceType : uint8_t {
     CommunicationModule = 4,
     SensorHub           = 5,
     LED                 = 6,
-    ESCHub              = 7
+    ESCHub              = 7,
+    RobotControlHub     = 8,
 };
 
 /**
@@ -75,6 +76,16 @@ enum class MsgTypeESCHub : uint8_t {
     Gain                       = 0,
     AngularVelocities          = 1,
     AngularVelocitiesFeedbacks = 2,
+};
+
+/**
+ * @brief ESCHubのメッセージの種類(コマンド)
+ *
+ */
+enum class MsgTypeRobotControlHub : uint8_t {
+    Init     = 0,
+    Command  = 1,
+    Feedback = 2,
 };
 
 /**

--- a/include/gn10_can/devices/robot_control_hub_client.hpp
+++ b/include/gn10_can/devices/robot_control_hub_client.hpp
@@ -5,7 +5,7 @@
  * @version 0.1
  * @date 2026-04-12
  *
- * @copyright Copyright (c) 2026
+ * @copyright Copyright (c) 2026 ararobo
  *
  */
 #pragma once

--- a/include/gn10_can/devices/robot_control_hub_client.hpp
+++ b/include/gn10_can/devices/robot_control_hub_client.hpp
@@ -44,6 +44,19 @@ public:
         return false;
     }
 
+    void on_receive(const FDCANFrame& frame) override
+    {
+        auto id_fields = id::unpack(frame.id);
+        if (id_fields.is_command(id::MsgTypeRobotControlHub::Feedback)) {
+            if (frame.dlc == sizeof(Feedback)) {
+                Feedback feedback;
+                if (converter::unpack(frame.data.data(), frame.dlc, 0, feedback)) {
+                    feedback_ = feedback;
+                }
+            }
+        }
+    }
+
 private:
     std::optional<Feedback> feedback_;
 };

--- a/include/gn10_can/devices/robot_control_hub_client.hpp
+++ b/include/gn10_can/devices/robot_control_hub_client.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <optional>
+
 #include "gn10_can/core/fdcan_device.hpp"
 #include "gn10_can/utils/can_converter.hpp"
 
@@ -32,7 +34,18 @@ public:
         bus_.send_frame(frame);
     }
 
+    bool get_feedback(Feedback& feedback)
+    {
+        if (feedback_.has_value()) {
+            feedback = feedback_.value();
+            feedback_.reset();
+            return true;
+        }
+        return false;
+    }
+
 private:
+    std::optional<Feedback> feedback_;
 };
 
 }  // namespace devices

--- a/include/gn10_can/devices/robot_control_hub_client.hpp
+++ b/include/gn10_can/devices/robot_control_hub_client.hpp
@@ -1,3 +1,13 @@
+/**
+ * @file robot_control_hub_client.hpp
+ * @author Gento Aiba (aiba-gento)
+ * @brief ロボットを統括し、PCとの橋渡しを担うデバイスのクライアント(PC側)クラス
+ * @version 0.1
+ * @date 2026-04-12
+ *
+ * @copyright Copyright (c) 2026
+ *
+ */
 #pragma once
 #include <optional>
 

--- a/include/gn10_can/devices/robot_control_hub_client.hpp
+++ b/include/gn10_can/devices/robot_control_hub_client.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "gn10_can/core/fdcan_device.hpp"
+
+namespace gn10_can {
+namespace devices {
+
+/**
+ * @brief RobotControlHubのクライアント用デバイスクラス(PCなどを想定)
+ *
+ * @tparam Command 指令値のデータ構造体
+ * @tparam Feedback フィードバックのデータ構造体
+ */
+template <typename Command, typename Feedback>
+class RobotControlHubClient : public FDCANDevice
+{
+public:
+    RobotControlHubClient(FDCANBus& bus, uint8_t dev_id)
+        : FDCANDevice(bus, id::DeviceType::RobotControlHub, dev_id)
+    {
+        static_assert(sizeof(Command) <= 64, "Command size exceeds FDCAN limit (64bytes)");
+        static_assert(sizeof(Feedback) <= 64, "Feedback size exceeds FDCAN limit (64bytes)");
+    }
+
+private:
+};
+
+}  // namespace devices
+}  // namespace gn10_can

--- a/include/gn10_can/devices/robot_control_hub_client.hpp
+++ b/include/gn10_can/devices/robot_control_hub_client.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "gn10_can/core/fdcan_device.hpp"
+#include "gn10_can/utils/can_converter.hpp"
 
 namespace gn10_can {
 namespace devices {
@@ -19,6 +20,16 @@ public:
     {
         static_assert(sizeof(Command) <= 64, "Command size exceeds FDCAN limit (64bytes)");
         static_assert(sizeof(Feedback) <= 64, "Feedback size exceeds FDCAN limit (64bytes)");
+    }
+
+    void send_command(const Command& command)
+    {
+        FDCANFrame frame = FDCANFrame::make(
+            id::DeviceType::RobotControlHub, device_id_, id::MsgTypeRobotControlHub::Command
+        );
+        converter::pack(frame.data, 0, command);
+        frame.dlc = sizeof(Command);
+        bus_.send_frame(frame);
     }
 
 private:

--- a/include/gn10_can/devices/robot_control_hub_server.hpp
+++ b/include/gn10_can/devices/robot_control_hub_server.hpp
@@ -44,6 +44,19 @@ public:
         bus_.send_frame(frame);
     }
 
+    void on_receive(const FDCANFrame& frame) override
+    {
+        auto id_fields = id::unpack(frame.id);
+        if (id_fields.is_command(id::MsgTypeRobotControlHub::Command)) {
+            if (frame.dlc == sizeof(Command)) {
+                Command command;
+                if (converter::unpack(frame.data.data(), frame.dlc, 0, command)) {
+                    command_ = command;
+                }
+            }
+        }
+    }
+
 private:
     std::optional<Command> command_;
 };

--- a/include/gn10_can/devices/robot_control_hub_server.hpp
+++ b/include/gn10_can/devices/robot_control_hub_server.hpp
@@ -5,7 +5,7 @@
  * @version 0.1
  * @date 2026-04-12
  *
- * @copyright Copyright (c) 2026
+ * @copyright Copyright (c) 2026 ararobo
  *
  */
 #pragma once

--- a/include/gn10_can/devices/robot_control_hub_server.hpp
+++ b/include/gn10_can/devices/robot_control_hub_server.hpp
@@ -2,6 +2,7 @@
 #include <optional>
 
 #include "gn10_can/core/fdcan_device.hpp"
+#include "gn10_can/utils/can_converter.hpp"
 
 namespace gn10_can {
 namespace devices {
@@ -31,6 +32,16 @@ public:
             return true;
         }
         return false;
+    }
+
+    void send_feedback(const Feedback& feedback)
+    {
+        FDCANFrame frame = FDCANFrame::make(
+            id::DeviceType::RobotControlHub, device_id_, id::MsgTypeRobotControlHub::Feedback
+        );
+        converter::pack(frame.data, 0, feedback);
+        frame.dlc = sizeof(Feedback);
+        bus_.send_frame(frame);
     }
 
 private:

--- a/include/gn10_can/devices/robot_control_hub_server.hpp
+++ b/include/gn10_can/devices/robot_control_hub_server.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <optional>
+
 #include "gn10_can/core/fdcan_device.hpp"
 
 namespace gn10_can {
@@ -21,7 +23,18 @@ public:
         static_assert(sizeof(Feedback) <= 64, "Feedback size exceeds FDCAN limit (64bytes)");
     }
 
+    bool get_command(Command& command)
+    {
+        if (command_.has_value()) {
+            command = command_.value();
+            command_.reset();
+            return true;
+        }
+        return false;
+    }
+
 private:
+    std::optional<Command> command_;
 };
 
 }  // namespace devices

--- a/include/gn10_can/devices/robot_control_hub_server.hpp
+++ b/include/gn10_can/devices/robot_control_hub_server.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "gn10_can/core/fdcan_device.hpp"
+
+namespace gn10_can {
+namespace devices {
+
+/**
+ * @brief RobotControlHubのサーバー用デバイスクラス(ロボットを統括し、PCとの橋渡しを担う基板)
+ *
+ * @tparam Command 指令値のデータ構造体
+ * @tparam Feedback フィードバックのデータ構造体
+ */
+template <typename Command, typename Feedback>
+class RobotControlHubServer : public FDCANDevice
+{
+public:
+    RobotControlHubServer(FDCANBus& bus, uint8_t dev_id)
+        : FDCANDevice(bus, id::DeviceType::RobotControlHub, dev_id)
+    {
+        static_assert(sizeof(Command) <= 64, "Command size exceeds FDCAN limit (64bytes)");
+        static_assert(sizeof(Feedback) <= 64, "Feedback size exceeds FDCAN limit (64bytes)");
+    }
+
+private:
+};
+
+}  // namespace devices
+}  // namespace gn10_can

--- a/include/gn10_can/devices/robot_control_hub_server.hpp
+++ b/include/gn10_can/devices/robot_control_hub_server.hpp
@@ -1,3 +1,13 @@
+/**
+ * @file robot_control_hub_server.hpp
+ * @author Gento Aiba (aiba-gento)
+ * @brief ロボットを統括し、PCとの橋渡しを担うデバイスのサーバー(マイコン側)クラス
+ * @version 0.1
+ * @date 2026-04-12
+ *
+ * @copyright Copyright (c) 2026
+ *
+ */
 #pragma once
 #include <optional>
 


### PR DESCRIPTION
ロボットとPCを橋渡しする通信を定義するため、新規デバイス追加。
テンプレートを利用して通信データを変更可能になるよう実装。

Initメッセージは未実装だが、他デバイスとの互換性を考えIDのみ用意。