### PR TITLE
電源管理デバイス追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCES
     src/devices/servo_motor_server.cpp
     src/devices/solenoid_driver_client.cpp
     src/devices/solenoid_driver_server.cpp
+    src/devices/power_manager_client.cpp
 )
 
 # Option to enable STM32 drivers (Requires HAL headers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES
     src/devices/solenoid_driver_client.cpp
     src/devices/solenoid_driver_server.cpp
     src/devices/power_manager_client.cpp
+    src/devices/power_manager_server.cpp
 )
 
 # Option to enable STM32 drivers (Requires HAL headers)

--- a/include/gn10_can/core/can_id.hpp
+++ b/include/gn10_can/core/can_id.hpp
@@ -41,9 +41,9 @@ enum class DeviceType : uint8_t {
  *
  */
 enum class MsgTypePowerManager : uint8_t {
-    Init    = 0,
-    Command = 1,
-    Status  = 2,
+    Init   = 0,
+    Stop   = 1,
+    Status = 2,
 };
 
 /**

--- a/include/gn10_can/core/can_id.hpp
+++ b/include/gn10_can/core/can_id.hpp
@@ -44,6 +44,7 @@ enum class MsgTypePowerManager : uint8_t {
     Init   = 0,
     Stop   = 1,
     Status = 2,
+    Sensor = 3,
 };
 
 /**

--- a/include/gn10_can/core/can_id.hpp
+++ b/include/gn10_can/core/can_id.hpp
@@ -25,7 +25,7 @@ static constexpr uint8_t BIT_WIDTH_COMMAND  = 3;
  *
  */
 enum class DeviceType : uint8_t {
-    EmergencyStop       = 0,
+    PowerManager        = 0,
     MotorDriver         = 1,
     ServoMotor          = 2,
     SolenoidDriver      = 3,
@@ -37,13 +37,13 @@ enum class DeviceType : uint8_t {
 };
 
 /**
- * @brief 非常停止スイッチのメッセージ種類（コマンド）
+ * @brief 電源管理基板のメッセージ種類（コマンド）
  *
  */
-enum class MsgTypeEmergencyStop : uint8_t {
-    Init          = 0,
-    Status        = 1,
-    EmergencyStop = 2,
+enum class MsgTypePowerManager : uint8_t {
+    Init    = 0,
+    Command = 1,
+    Status  = 2,
 };
 
 /**

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -2,7 +2,6 @@
 #include <optional>
 
 #include "gn10_can/core/fdcan_device.hpp"
-#include "gn10_can/utils/can_converter.hpp"
 
 namespace gn10_can {
 namespace devices {

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <optional>
+
+#include "gn10_can/core/fdcan_device.hpp"
+#include "gn10_can/utils/can_converter.hpp"
+
+namespace gn10_can {
+namespace devices {
+
+class PowerManagerClient : public FDCANDevice
+{
+public:
+    PowerManagerClient(FDCANBus& bus, uint8_t dev_id);
+
+    void set_init();
+
+    void set_stop(bool enable_stop);
+
+    bool get_feedback(bool enable_stop, float voltage, float current);
+
+    void on_receive(const FDCANFrame& frame) override;
+
+private:
+};
+}  // namespace devices
+}  // namespace gn10_can

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -34,7 +34,7 @@ public:
     void on_receive(const FDCANFrame& frame) override;
 
 private:
-    std::optional<Status> feedback_;
+    std::optional<Status> status_;
 };
 }  // namespace devices
 }  // namespace gn10_can

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -7,6 +7,12 @@
 namespace gn10_can {
 namespace devices {
 
+struct Feedback {
+    bool enable_stop;
+    float voltage;
+    float current;
+};
+
 class PowerManagerClient : public FDCANDevice
 {
 public:
@@ -16,14 +22,12 @@ public:
 
     void set_stop(bool enable_stop);
 
-    void get_feedback(bool& enable_stop, float& voltage, float& current);
+    bool get_feedback(Feedback& feedback);
 
     void on_receive(const FDCANFrame& frame) override;
 
 private:
-    bool enable_stop_;
-    float voltage_;
-    float current_;
+    std::optional<Feedback> feedback_;
 };
 }  // namespace devices
 }  // namespace gn10_can

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -16,11 +16,14 @@ public:
 
     void set_stop(bool enable_stop);
 
-    bool get_feedback(bool enable_stop, float voltage, float current);
+    void get_feedback(bool& enable_stop, float& voltage, float& current);
 
     void on_receive(const FDCANFrame& frame) override;
 
 private:
+    bool enable_stop_;
+    float voltage_;
+    float current_;
 };
 }  // namespace devices
 }  // namespace gn10_can

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -6,7 +6,7 @@
 namespace gn10_can {
 namespace devices {
 
-struct Feedback {
+struct Status {
     bool enable_stop;
     float voltage;
     float current;
@@ -21,12 +21,12 @@ public:
 
     void set_stop(bool enable_stop);
 
-    bool get_feedback(Feedback& feedback);
+    bool get_status(Status& feedback);
 
     void on_receive(const FDCANFrame& frame) override;
 
 private:
-    std::optional<Feedback> feedback_;
+    std::optional<Status> feedback_;
 };
 }  // namespace devices
 }  // namespace gn10_can

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -27,9 +27,9 @@ public:
 
     void set_stop(bool enable_stop);
 
-    bool get_status(Status& status);
+    bool get_new_status(Status& status);
 
-    bool get_sensor(Sensor& sensor);
+    bool get_new_sensor(Sensor& sensor);
 
     void on_receive(const FDCANFrame& frame) override;
 

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -35,6 +35,7 @@ public:
 
 private:
     std::optional<Status> status_;
+    std::optional<Sensor> sensor_;
 };
 }  // namespace devices
 }  // namespace gn10_can

--- a/include/gn10_can/devices/power_manager_client.hpp
+++ b/include/gn10_can/devices/power_manager_client.hpp
@@ -7,7 +7,13 @@ namespace gn10_can {
 namespace devices {
 
 struct Status {
-    bool enable_stop;
+    bool emergency_stop_enabled;
+    bool remote_emergency_stop_connected;
+    bool remote_emergency_stop_enabled;
+    bool over_current;
+};
+
+struct Sensor {
     float voltage;
     float current;
 };
@@ -21,7 +27,9 @@ public:
 
     void set_stop(bool enable_stop);
 
-    bool get_status(Status& feedback);
+    bool get_status(Status& status);
+
+    bool get_sensor(Sensor& sensor);
 
     void on_receive(const FDCANFrame& frame) override;
 

--- a/include/gn10_can/devices/power_manager_server.hpp
+++ b/include/gn10_can/devices/power_manager_server.hpp
@@ -6,7 +6,7 @@
 namespace gn10_can {
 namespace devices {
 
-struct Feedback {
+struct Status {
     bool enable_stop;
     float voltage;
     float current;
@@ -21,7 +21,7 @@ public:
 
     bool get_stop(bool& enable_stop);
 
-    void set_feedback(Feedback feedback);
+    void set_feedback(Status feedback);
 
     void on_receive(const FDCANFrame& frame) override;
 

--- a/include/gn10_can/devices/power_manager_server.hpp
+++ b/include/gn10_can/devices/power_manager_server.hpp
@@ -23,9 +23,9 @@ class PowerManagerServer : public FDCANDevice
 public:
     PowerManagerServer(FDCANBus& bus, uint8_t dev_id);
 
-    bool get_init();
+    bool get_new_init();
 
-    bool get_stop(bool& enable_stop);
+    bool get_new_stop(bool& enable_stop);
 
     void set_status(Status status);
 

--- a/include/gn10_can/devices/power_manager_server.hpp
+++ b/include/gn10_can/devices/power_manager_server.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <optional>
+
+#include "gn10_can/core/fdcan_device.hpp"
+
+namespace gn10_can {
+namespace devices {
+
+struct Feedback {
+    bool enable_stop;
+    float voltage;
+    float current;
+};
+
+class PowerManagerServer : public FDCANDevice
+{
+public:
+    PowerManagerServer(FDCANBus& bus, uint8_t dev_id);
+
+    bool get_init();
+
+    bool get_stop(bool& enable_stop);
+
+    void set_feedback(Feedback feedback);
+
+    void on_receive(const FDCANFrame& frame) override;
+
+private:
+    std::optional<uint8_t> init_;
+    std::optional<bool> enable_stop_;
+};
+}  // namespace devices
+}  // namespace gn10_can

--- a/include/gn10_can/devices/power_manager_server.hpp
+++ b/include/gn10_can/devices/power_manager_server.hpp
@@ -7,7 +7,13 @@ namespace gn10_can {
 namespace devices {
 
 struct Status {
-    bool enable_stop;
+    bool emergency_stop_enabled;
+    bool remote_emergency_stop_connected;
+    bool remote_emergency_stop_enabled;
+    bool over_current;
+};
+
+struct Sensor {
     float voltage;
     float current;
 };
@@ -21,7 +27,9 @@ public:
 
     bool get_stop(bool& enable_stop);
 
-    void set_feedback(Status feedback);
+    void set_status(Status status);
+
+    void set_sensor(Sensor sensor);
 
     void on_receive(const FDCANFrame& frame) override;
 

--- a/src/devices/power_manager_client.cpp
+++ b/src/devices/power_manager_client.cpp
@@ -23,11 +23,21 @@ void PowerManagerClient::set_stop(bool enable_stop)
     send(id::MsgTypePowerManager::Stop, payload);
 }
 
-bool PowerManagerClient::get_status(Status& feedback)
+bool PowerManagerClient::get_status(Status& status)
 {
-    if (feedback_.has_value()) {
-        feedback = feedback_.value();
-        feedback_.reset();
+    if (status_.has_value()) {
+        status = status_.value();
+        status_.reset();
+        return true;
+    }
+    return false;
+}
+
+bool PowerManagerClient::get_sensor(Sensor& sensor)
+{
+    if (sensor_.has_value()) {
+        sensor = sensor_.value();
+        sensor_.reset();
         return true;
     }
     return false;
@@ -37,14 +47,26 @@ void PowerManagerClient::on_receive(const FDCANFrame& frame)
 {
     auto id_fields = id::unpack(frame.id);
     if (id_fields.is_command(id::MsgTypePowerManager::Status)) {
-        bool enable_stop;
-        float voltage, current;
-        if (converter::unpack(frame.data.data(), frame.dlc, 0, enable_stop) &&
-            converter::unpack(frame.data.data(), frame.dlc, 1, voltage) &&
-            converter::unpack(frame.data.data(), frame.dlc, 5, current)) {
-            feedback_.value().enable_stop = enable_stop;
-            feedback_.value().voltage     = voltage;
-            feedback_.value().current     = current;
+        bool emergency_stop_enabled;
+        bool remote_emergency_stop_connected;
+        bool remote_emergency_stop_enabled;
+        bool over_current;
+        if (converter::unpack(frame.data.data(), frame.dlc, 0, emergency_stop_enabled) &&
+            converter::unpack(frame.data.data(), frame.dlc, 1, remote_emergency_stop_connected) &&
+            converter::unpack(frame.data.data(), frame.dlc, 5, remote_emergency_stop_enabled) &&
+            converter::unpack(frame.data.data(), frame.dlc, 3, over_current)) {
+            status_.value().emergency_stop_enabled          = emergency_stop_enabled;
+            status_.value().remote_emergency_stop_connected = remote_emergency_stop_connected;
+            status_.value().remote_emergency_stop_enabled   = remote_emergency_stop_enabled;
+            status_.value().over_current                    = over_current;
+        }
+    } else if (id_fields.is_command(id::MsgTypePowerManager::Sensor)) {
+        float voltage;
+        float current;
+        if (converter::unpack(frame.data.data(), frame.dlc, 0, voltage) &&
+            converter::unpack(frame.data.data(), frame.dlc, 4, current)) {
+            sensor_.value().voltage = voltage;
+            sensor_.value().current = current;
         }
     }
 }

--- a/src/devices/power_manager_client.cpp
+++ b/src/devices/power_manager_client.cpp
@@ -1,0 +1,52 @@
+#include "gn10_can/devices/power_manager_client.hpp"
+
+#include "gn10_can/utils/can_converter.hpp"
+
+namespace gn10_can {
+
+namespace devices {
+PowerManagerClient::PowerManagerClient(FDCANBus& bus, uint8_t dev_id)
+    : FDCANDevice(bus, id::DeviceType::PowerManager, dev_id)
+{
+}
+
+void PowerManagerClient::set_init()
+{
+    send(id::MsgTypePowerManager::Init, 0);
+}
+
+void PowerManagerClient::set_stop(bool enable_stop)
+{
+    std::array<uint8_t, 1> payload{};
+    converter::pack(payload, 0, enable_stop);
+    send(id::MsgTypePowerManager::Stop, payload);
+}
+
+bool PowerManagerClient::get_feedback(Feedback& feedback)
+{
+    if (feedback_.has_value()) {
+        feedback = feedback_.value();
+        feedback_.reset();
+        return true;
+    }
+    return false;
+}
+
+void PowerManagerClient::on_receive(const FDCANFrame& frame)
+{
+    auto id_fields = id::unpack(frame.id);
+    if (id_fields.is_command(id::MsgTypePowerManager::Status)) {
+        bool enable_stop;
+        float voltage, current;
+        if (converter::unpack(frame.data.data(), frame.dlc, 0, enable_stop) &&
+            converter::unpack(frame.data.data(), frame.dlc, 1, voltage) &&
+            converter::unpack(frame.data.data(), frame.dlc, 5, current)) {
+            feedback_.value().enable_stop = enable_stop;
+            feedback_.value().voltage     = voltage;
+            feedback_.value().current     = current;
+        }
+    }
+}
+
+}  // namespace devices
+}  // namespace gn10_can

--- a/src/devices/power_manager_client.cpp
+++ b/src/devices/power_manager_client.cpp
@@ -12,7 +12,8 @@ PowerManagerClient::PowerManagerClient(FDCANBus& bus, uint8_t dev_id)
 
 void PowerManagerClient::set_init()
 {
-    send(id::MsgTypePowerManager::Init, 0);
+    std::array<uint8_t, 1> payload{};
+    send(id::MsgTypePowerManager::Init, payload);
 }
 
 void PowerManagerClient::set_stop(bool enable_stop)

--- a/src/devices/power_manager_client.cpp
+++ b/src/devices/power_manager_client.cpp
@@ -22,7 +22,7 @@ void PowerManagerClient::set_stop(bool enable_stop)
     send(id::MsgTypePowerManager::Stop, payload);
 }
 
-bool PowerManagerClient::get_feedback(Feedback& feedback)
+bool PowerManagerClient::get_status(Status& feedback)
 {
     if (feedback_.has_value()) {
         feedback = feedback_.value();

--- a/src/devices/power_manager_client.cpp
+++ b/src/devices/power_manager_client.cpp
@@ -23,7 +23,7 @@ void PowerManagerClient::set_stop(bool enable_stop)
     send(id::MsgTypePowerManager::Stop, payload);
 }
 
-bool PowerManagerClient::get_status(Status& status)
+bool PowerManagerClient::get_new_status(Status& status)
 {
     if (status_.has_value()) {
         status = status_.value();
@@ -33,7 +33,7 @@ bool PowerManagerClient::get_status(Status& status)
     return false;
 }
 
-bool PowerManagerClient::get_sensor(Sensor& sensor)
+bool PowerManagerClient::get_new_sensor(Sensor& sensor)
 {
     if (sensor_.has_value()) {
         sensor = sensor_.value();

--- a/src/devices/power_manager_server.cpp
+++ b/src/devices/power_manager_server.cpp
@@ -1,0 +1,57 @@
+#include "gn10_can/devices/power_manager_server.hpp"
+
+#include "gn10_can/utils/can_converter.hpp"
+
+namespace gn10_can {
+namespace devices {
+
+PowerManagerServer::PowerManagerServer(FDCANBus& bus, uint8_t dev_id)
+    : FDCANDevice(bus, id::DeviceType::PowerManager, dev_id)
+{
+}
+
+bool PowerManagerServer::get_init()
+{
+    if (init_.has_value()) {
+        init_.reset();
+        return true;
+    }
+    return false;
+}
+
+bool PowerManagerServer::get_stop(bool& enable_stop)
+{
+    if (enable_stop_.has_value()) {
+        enable_stop = enable_stop_.value();
+        enable_stop_.reset();
+        return true;
+    }
+    return false;
+}
+
+void PowerManagerServer::set_feedback(Status feedback)
+{
+    std::array<uint8_t, sizeof(Status)> payload{};
+    converter::pack(payload, 0, feedback);
+    send(id::MsgTypePowerManager::Status, payload);
+}
+
+void PowerManagerServer::on_receive(const FDCANFrame& frame)
+{
+    auto id_fields = id::unpack(frame.id);
+    if (id_fields.is_command(id::MsgTypePowerManager::Init)) {
+        uint8_t init;
+        if (converter::unpack(frame.data.data(), frame.dlc, 0, init)) {
+            init_.value() = init;
+        }
+    }
+    if (id_fields.is_command(id::MsgTypePowerManager::Stop)) {
+        bool enable_stop;
+        if (converter::unpack(frame.data.data(), frame.dlc, 0, enable_stop)) {
+            enable_stop_.value() = enable_stop;
+        }
+    }
+}
+
+}  // namespace devices
+}  // namespace gn10_can

--- a/src/devices/power_manager_server.cpp
+++ b/src/devices/power_manager_server.cpp
@@ -10,7 +10,7 @@ PowerManagerServer::PowerManagerServer(FDCANBus& bus, uint8_t dev_id)
 {
 }
 
-bool PowerManagerServer::get_init()
+bool PowerManagerServer::get_new_init()
 {
     if (init_.has_value()) {
         init_.reset();
@@ -19,7 +19,7 @@ bool PowerManagerServer::get_init()
     return false;
 }
 
-bool PowerManagerServer::get_stop(bool& enable_stop)
+bool PowerManagerServer::get_new_stop(bool& enable_stop)
 {
     if (enable_stop_.has_value()) {
         enable_stop = enable_stop_.value();

--- a/src/devices/power_manager_server.cpp
+++ b/src/devices/power_manager_server.cpp
@@ -29,11 +29,22 @@ bool PowerManagerServer::get_stop(bool& enable_stop)
     return false;
 }
 
-void PowerManagerServer::set_feedback(Status feedback)
+void PowerManagerServer::set_status(Status status)
 {
-    std::array<uint8_t, sizeof(Status)> payload{};
-    converter::pack(payload, 0, feedback);
+    std::array<uint8_t, 4> payload{};
+    converter::pack(payload, 0, status.emergency_stop_enabled);
+    converter::pack(payload, 1, status.remote_emergency_stop_connected);
+    converter::pack(payload, 2, status.remote_emergency_stop_enabled);
+    converter::pack(payload, 3, status.over_current);
     send(id::MsgTypePowerManager::Status, payload);
+}
+
+void PowerManagerServer::set_sensor(Sensor sensor)
+{
+    std::array<uint8_t, 8> payload{};
+    converter::pack(payload, 0, sensor.voltage);
+    converter::pack(payload, 4, sensor.current);
+    send(id::MsgTypePowerManager::Sensor, payload);
 }
 
 void PowerManagerServer::on_receive(const FDCANFrame& frame)


### PR DESCRIPTION
電源管理基板用にデバイスを追加し、実装した。
電源管理の機能は以下：
- 非常停止
- 電圧・電流監視

CANFDのみ対応